### PR TITLE
Separate bundle into earlier step.

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,16 +1,21 @@
 VERSION 0.8
 
+bundle:
+	FROM docker.io/library/ruby:3.3
+	COPY --dir Gemfile Gemfile.lock \
+		/src/site
+	WORKDIR /src/site
+	RUN bundle install
+
 nanoc:
 	#FROM docker.io/library/ruby:3.3-alpine
-	FROM docker.io/library/ruby:3.3
+	FROM +bundle
 	COPY --dir content layouts lib Gemfile Gemfile.lock Rules nanoc.yaml \
 		/src/site/
-	WORKDIR /src/site
 
 
 build:
 	FROM +nanoc
-	RUN bundle install
 	RUN bundle exec nanoc
 	SAVE ARTIFACT output AS LOCAL output
 


### PR DESCRIPTION
Copying just the bundler configurations and running bundle install in the earlier step dramatically cuts down on iteration time since the bundle install will only re-run if the gems actually change.