### PR TITLE
Update Actions workflows to support deploying to GitHub Pages.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,9 @@ jobs:
       - uses: earthly/actions-setup@v1
       - name: nanoc compile
         run: |
-          earthly --ci +build
-  upload:
-    runs-on: ubuntu-22.04
-    if: ${{ github.event_name == "push" }}
-    needs: compile
-    steps:
-      - uses: actions/upload-pages-artifact@v3
+          earthly --output --ci +build
+      - name: Upload for GitHub Pages
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-pages-artifact@v3
         with:
           path: output

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+---
+name: CI
 on:
   push:
     branches: ["main"]
@@ -13,3 +15,11 @@ jobs:
       - name: nanoc compile
         run: |
           earthly --ci +build
+  upload:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == "push" }}
+    needs: compile
+    steps:
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: output

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,33 @@
+---
+name: Deploy to GitHub Pages
+on:
+  # NOTE: As of 2024-08-15, this event will only trigger a workflow run if
+  # the workflow file is on the default branch.
+  # This is our desired behavior but if this default ever changes we may need
+  # to add additional guard clauses to make sure we are only deploying
+  # artifacts from the main branch.
+  #
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
+  workflow_run:
+    workflows: ['CI']
+    types: ['completed']
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ github_event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
It's our goal to deploy this site using GitHub Pages.
I've added an `upload` job to our current CI, which only triggers when the workflow was started by a push to `main` and an additional `Deploy to GitHub Pages` workflow which runs whenever the CI workflow runs on `main` and deploys the uploaded pages artifact on success.